### PR TITLE
Use Python 3 highlighter when ran in Python 3 environment

### DIFF
--- a/pdoc/templates/html.mako
+++ b/pdoc/templates/html.mako
@@ -47,7 +47,11 @@
     if not use_pygments:  # :-(
       return '<pre><code>%s</code></pre>' % (''.join(lines))
 
-    pylex = pygments.lexers.PythonLexer()
+    if sys.version_info[0] < 3:
+        pylex = pygments.lexers.PythonLexer()
+    else:
+        pylex = pygments.lexers.Python3Lexer()
+
     htmlform = pygments.formatters.HtmlFormatter(cssclass='codehilite')
     return pygments.highlight(''.join(lines), pylex, htmlform)
 

--- a/setup.py
+++ b/setup.py
@@ -52,5 +52,5 @@ setup(
     provides=['pdoc'],
     requires=['argparse', 'mako', 'markdown'],
     install_requires=install_requires,
-    extras_require={'syntax_highlighting': ['pygments']},
+    extras_require={'syntax_highlighting': ['pygments>=0.10']},
 )


### PR DESCRIPTION
Among other things, this adds highlighting for the `async` keyword